### PR TITLE
Products Model Delete Boolean

### DIFF
--- a/Models/Products.cs
+++ b/Models/Products.cs
@@ -16,14 +16,15 @@ namespace BangazonAPI.Models
         
         public int Id { get; set; }
         
-        public int ProductTypeId { get; set; }
-        public ProductTypes ProductTypesId { get; set; }
+        public int ProductTypesId { get; set; }
+        public ProductTypes ProductType { get; set; }
         public int CustomersId { get; set; }
         public Customers Customer { get; set; }
         public int Price { get; set; }
         public string Title { get; set; } // ? means that the variable can be null
         public string Description { get; set; }
         public int Quantity { get; set; }
+        public Boolean IsDeleted { get; set; }
 
 
     }


### PR DESCRIPTION

Purpose:
 to be able to 'fake' delete products with a boolean
I also add the 's' in the product types foreign key id in the get/set that was missing.



How it fits in context of the project:
Allows a product to look deleted but doesn't cause conflict with foreign keys; the product will actually still be there in case you need to reference it later.
The 's' was necessary because it didn't match our sql file.


Specific Feature affected:
the Products.cs model



How to test (Be thorough!):

1. check out into this branch

2. confirm the boolean is present

3.confirm the 's' is present on ProductTypesId
